### PR TITLE
Fix #798 - RBAC for leader election

### DIFF
--- a/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
+++ b/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
@@ -64,11 +64,18 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - pods
       - secrets
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - update
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/ingress/issues/798

Using gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.7
the nginx-controller needs to handle leader-election via configmaps.

To perform the leader-election the nginx-controller needs to have the
appropiate RBAC permissions.

Previously to this fix, the following errors occured:

-  cannot get configmaps in the namespace "NAMESPACE_PLACEHOLDER". (get configmaps ingress-controller-leader-nginx)
- initially creating leader election record: User "system:serviceaccount:NAMESPACE_PLACEHOLDER" cannot create configmaps in the namespace "NAMESPACE_PLACEHOLDER". (post configmaps)

